### PR TITLE
Fix Invalid handler for event "load"

### DIFF
--- a/src/Components/Lightbox.vue
+++ b/src/Components/Lightbox.vue
@@ -18,7 +18,7 @@
                 </div>
                 <div class="lightbox__image" @click.stop="">
                     <slot name="loader" v-if="$slots.loader"></slot>
-                    <img :src="images[index]" @load="loaded" v-if="displayImage">
+                    <img :src="images[index]" v-if="displayImage">
                 </div>
                 <div
                     class="lightbox__arrow lightbox__arrow--right"


### PR DESCRIPTION
> [Vue warn]: Invalid handler for event "load": got undefined

`loaded` is not defined anywhere.