### PR TITLE
Added `show` prop

### DIFF
--- a/src/Components/Lightbox.vue
+++ b/src/Components/Lightbox.vue
@@ -46,10 +46,11 @@
             'thumbnail',
             'images',
             'alternateText',
+            'show'
         ],
         data() {
             return {
-                visible: false,
+                visible: this.show ? true : false,
                 index: 0,
                 displayImage: true,
             }


### PR DESCRIPTION
Is it an over-do to add a show prop to control the visibility?

For example, to activate the `lightbox` by clicking any image