### PR TITLE
Add prop 'openAt'

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Vue.use(VuePureLightbox)
 | images         | string[] or array | Array of paths to files visible in the lightbox |
 | alternate-text | string            | **(Optional)** alt="" text for your image       |
 | value          | boolean           | **(Optional)** reactive visibility prop         |
+| openAt         | integer           | **(Optional)** index of image to show on open   |
 
 ### Available slots:
 | Slot          | Description                                    | Default                              |

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,6 +3,7 @@
     class="lb-demo"
     :thumbnail="thumbnail"
     :images="images"
+    :openAt="1"
 >
     <LightboxDefaultLoader slot="loader" />
     <div slot="content" slot-scope="{ url }">

--- a/src/Components/Lightbox.vue
+++ b/src/Components/Lightbox.vue
@@ -58,6 +58,10 @@
       images: {
         type: Array,
       },
+      openAt: {
+        type: Number,
+        default: 0,
+      },
       alternateText: {
         type: String,
         default: '',
@@ -71,7 +75,7 @@
     data() {
       return {
         visible: this.value,
-        index: 0,
+        index: this.openAt,
         displayImage: true,
       }
     },
@@ -94,11 +98,11 @@
     methods: {
       show() {
         this.visible = true
-        this.index = 0
+        this.index = this.openAt
       },
       hide() {
         this.visible = false
-        this.index = 0
+        this.index = this.openAt
       },
       previous() {
         if (this.hasPrevious) {


### PR DESCRIPTION
This PR adds a prop `openAt` which allows to set the index of the image to show initially.

This is based on the changes from #15 because I wasn't able to build the project with the old build setup. It should however be possible to just cherry-pick f1e5a08.

Also I'm completely open for suggestions how to name this prop. I didn't use `index` because this was already used internally in the component. Naming things is hard.